### PR TITLE
Add SEO: per-page meta tags, OG-tags, JSON-LD, sitemap and robots.txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shine On You</title>
-    <meta name="description" content="Shine On You is a Pink Floyd tribute band from Norway." />
+    <title>Shine On You – Pink Floyd Tribute Band</title>
+    <meta name="description" content="Shine On You er Norges fremste Pink Floyd tributeband. Vi fremfører klassikere fra The Dark Side of the Moon, The Wall og Wish You Were Here live i Norge, Sverige og Skandinavia." />
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,0,0" />
     <script defer src="https://cloud.umami.is/script.js" data-website-id="6bda9b9b-037a-4b1a-87af-0341b1e12203"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.45.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^3.0.0",
         "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.2"
       },
@@ -2873,6 +2874,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3630,6 +3640,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
@@ -3865,6 +3895,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.45.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^3.0.0",
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.2"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://shineonyou.no/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://shineonyou.no/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://shineonyou.no/tour</loc>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://shineonyou.no/about</loc>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://shineonyou.no/gallery</loc>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -1,0 +1,35 @@
+import { Helmet } from 'react-helmet-async'
+
+const BASE_URL = 'https://shineonyou.no'
+const DEFAULT_OG_IMAGE = `${BASE_URL}/images/Banner Web.png`
+
+export default function SEO({ title, description, canonicalPath = '/', ogImage }) {
+  const fullTitle = title
+    ? `${title} | Shine On You`
+    : 'Shine On You – Pink Floyd Tribute Band'
+
+  const canonical = `${BASE_URL}${canonicalPath}`
+  const image = ogImage || DEFAULT_OG_IMAGE
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={canonical} />
+
+      {/* Open Graph */}
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={image} />
+      <meta property="og:site_name" content="Shine On You" />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+    </Helmet>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import './index.css'
 
@@ -12,6 +13,8 @@ if (redirectPath) {
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
   </React.StrictMode>,
 )

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import Nav from '../components/Nav'
 import Footer from '../components/Footer'
 import { supabase } from '../lib/supabase'
+import SEO from '../components/SEO'
 
 const MEMBERS = [
   { name: 'Pelle Anderson',          role: 'Guitar and vocals',           img: '/images/members/member-pelle-anderson.jpg' },
@@ -32,6 +33,11 @@ export default function AboutPage() {
 
   return (
     <div className="container">
+      <SEO
+        title="Om bandet – Shine On You Pink Floyd Tribute"
+        description="Lær mer om Shine On You, Pink Floyd tributebandet fra Norge. 10 musikere dedikert til å gjenskape Pink Floyds unike lydlandskap."
+        canonicalPath="/about"
+      />
       <Nav />
       <section className="about-page">
         <h2>About</h2>

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import Nav from '../components/Nav'
 import Footer from '../components/Footer'
 import { supabase } from '../lib/supabase'
+import SEO from '../components/SEO'
 
 export default function GalleryPage() {
   const [images, setImages] = useState([])
@@ -48,6 +49,11 @@ export default function GalleryPage() {
 
   return (
     <div className="container">
+      <SEO
+        title="Bilder – Shine On You Pink Floyd Tribute"
+        description="Fotogalleri fra Shine On You sine konserter og opptredener."
+        canonicalPath="/gallery"
+      />
       <Nav />
       <section className="gallery-page">
         <h2>Gallery</h2>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,36 @@
+import { Helmet } from 'react-helmet-async'
 import Nav from '../components/Nav'
 import Header from '../components/Header'
 import SocialMedia from '../components/SocialMedia'
 import Footer from '../components/Footer'
+import SEO from '../components/SEO'
+
+const MUSIC_GROUP_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'MusicGroup',
+  name: 'Shine On You',
+  description: 'Pink Floyd tribute band from Norway. Performing classics from The Dark Side of the Moon, The Wall, Wish You Were Here and Shine On You Crazy Diamond.',
+  url: 'https://shineonyou.no',
+  genre: 'Rock',
+  foundingLocation: { '@type': 'Place', name: 'Norway' },
+  sameAs: [
+    'https://www.facebook.com/ShineOnU21',
+    'https://www.instagram.com/shineonyou_official/',
+    'https://www.youtube.com/@shineonyou-gq7uc',
+  ],
+}
 
 export default function Home() {
   return (
     <div className="container">
+      <SEO
+        title="Shine On You – Pink Floyd Tribute Band"
+        description="Shine On You er Norges fremste Pink Floyd tributeband. Vi fremfører klassikere fra The Dark Side of the Moon, The Wall og Wish You Were Here live i Norge, Sverige og Skandinavia."
+        canonicalPath="/"
+      />
+      <Helmet>
+        <script type="application/ld+json">{JSON.stringify(MUSIC_GROUP_SCHEMA)}</script>
+      </Helmet>
       <Nav />
       <Header />
       <SocialMedia />

--- a/src/pages/TourPage.jsx
+++ b/src/pages/TourPage.jsx
@@ -1,10 +1,16 @@
 import Nav from '../components/Nav'
 import Events from '../components/Events'
 import Footer from '../components/Footer'
+import SEO from '../components/SEO'
 
 export default function TourPage() {
   return (
     <div className="container">
+      <SEO
+        title="Konserter & turné – Shine On You"
+        description="Se kommende konserter med Shine On You. Vi spiller over hele Norge og Sverige – sjekk turné-datoer og kjøp billetter."
+        canonicalPath="/tour"
+      />
       <Nav />
       <Events />
       <Footer />


### PR DESCRIPTION
- Install react-helmet-async and wrap app with HelmetProvider
- Add reusable SEO component with title, description, OG, Twitter Card and canonical URL
- Add unique title and meta description for each page (Home, About, Tour, Gallery)
- Add MusicGroup JSON-LD schema on Home page targeting Pink Floyd tribute band keywords
- Update index.html: lang="no", improved fallback title and description
- Add public/robots.txt and public/sitemap.xml