### PR TITLE
Fix footer floating up on large screens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,9 @@ h2{
 .container {
   max-width: auto;
   width: 95%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .slider-wrapper {
@@ -298,6 +301,7 @@ footer{
     text-align:center;
     padding:20px 0;
     font-size:small;
+    margin-top: auto;
 }
 
 .footer-contact-btn {


### PR DESCRIPTION
Use flexbox sticky-footer pattern on .container (min-height: 100vh, flex-direction: column) and margin-top: auto on footer, so it always sits at the bottom regardless of screen height — no media queries needed.