### PR TITLE
Legg til universell utforming (a11y) — WCAG 2.1 AA

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -70,7 +70,9 @@ export default function Events() {
 
   if (loading) return (
     <section id="events" className={styles.upcomingEvents}>
-      <div className="events-spinner" />
+      <div role="status" aria-label="Laster konserter">
+        <div className="events-spinner" />
+      </div>
     </section>
   )
   if (error) return (
@@ -82,7 +84,7 @@ export default function Events() {
   return (
     <section id="events" className={styles.upcomingEvents}>
       <div className={styles.tourHeading}>
-        <h2>{settings.tour_heading}</h2>
+        <h1>{settings.tour_heading}</h1>
       </div>
       {upcoming.map((event) => (
         <EventCard key={event.id} event={event} />

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -3,13 +3,16 @@ import styles from './Nav.module.css'
 
 export default function Nav() {
   return (
-    <nav className={styles.mainNav}>
-      <ul className={styles.navLinks}>
-        <li><NavLink to="/">Home</NavLink></li>
-        <li><NavLink to="/tour">Tour</NavLink></li>
-        <li><NavLink to="/about">About</NavLink></li>
-        <li><NavLink to="/gallery">Gallery</NavLink></li>
-      </ul>
-    </nav>
+    <>
+      <a href="#main-content" className={styles.skipLink}>Hopp til innhold</a>
+      <nav className={styles.mainNav}>
+        <ul className={styles.navLinks}>
+          <li><NavLink to="/">Home</NavLink></li>
+          <li><NavLink to="/tour">Tour</NavLink></li>
+          <li><NavLink to="/about">About</NavLink></li>
+          <li><NavLink to="/gallery">Gallery</NavLink></li>
+        </ul>
+      </nav>
+    </>
   )
 }

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -1,3 +1,25 @@
+/* Hopp til innhold — synlig kun ved tastaturfokus */
+.skipLink {
+  position: absolute;
+  top: -48px;
+  left: 0;
+  background: #cc0000;
+  color: #fff;
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  z-index: 9999;
+  transition: top 0.15s;
+  border-radius: 0 0 4px 0;
+}
+
+.skipLink:focus {
+  top: 0;
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
 .mainNav {
   background: #000;
   padding: 14px 0;

--- a/src/components/__tests__/Events.test.jsx
+++ b/src/components/__tests__/Events.test.jsx
@@ -61,6 +61,7 @@ test('viser events normalt ved vellykket fetch', async () => {
   render(<Events />)
 
   await waitFor(() => {
-    expect(screen.getByText('Rockefeller, Oslo NO')).toBeInTheDocument()
+    expect(screen.getByText('Rockefeller')).toBeInTheDocument()
+    expect(screen.getByText('Oslo, NO')).toBeInTheDocument()
   })
 })

--- a/src/index.css
+++ b/src/index.css
@@ -45,9 +45,34 @@ footer{
     margin-top: auto;
 }
 
+h1 {
+  text-align: center;
+  font-size: 30px;
+}
+
 h2{
     text-align:center;
     font-size:30px;
+}
+
+/* Visually hidden — tilgjengelig for skjermlesere, usynlig visuelt */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Synlig tastaturfokus for alle interaktive elementer */
+:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+  border-radius: 2px;
 }
 
 /* Container — used on all pages as layout wrapper */

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -34,11 +34,12 @@ export default function AboutPage() {
         canonicalPath="/about"
       />
       <Nav />
+      <main id="main-content">
       <section className={styles.aboutPage}>
-        <h2>About</h2>
+        <h1>About</h1>
         <div className={styles.aboutBio}>
           {loading
-            ? <div className="events-spinner" />
+            ? <div role="status" aria-label="Laster innhold"><div className="events-spinner" /></div>
             : paragraphs.map((para, i) => (
                 <p key={i} className={i === 0 ? styles.aboutTagline : undefined}>{para}</p>
               ))
@@ -57,6 +58,7 @@ export default function AboutPage() {
 
         <p className={styles.membersPhotoCredit}>Photo: Espen Håkonsen</p>
       </section>
+      </main>
       <Footer />
     </div>
   )

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import Nav from '../components/Nav'
 import Footer from '../components/Footer'
 import { supabase } from '../lib/supabase'
@@ -10,6 +10,9 @@ export default function GalleryPage() {
   const [photoCredit, setPhotoCredit] = useState('')
   const [loading, setLoading] = useState(true)
   const [selected, setSelected] = useState(null)
+  const lightboxRef = useRef(null)
+  const closeButtonRef = useRef(null)
+  const triggerRef = useRef(null)
 
   useEffect(() => {
     const fetchData = async () => {
@@ -28,6 +31,46 @@ export default function GalleryPage() {
     supabase.storage.from('gallery').getPublicUrl(path).data.publicUrl
 
   const close = useCallback(() => setSelected(null), [])
+
+  // Flytt fokus til lukk-knappen når lightboxen åpnes
+  useEffect(() => {
+    if (selected !== null && closeButtonRef.current) {
+      closeButtonRef.current.focus()
+    }
+  }, [selected])
+
+  // Returner fokus til trigger-knappen når lightboxen lukkes
+  useEffect(() => {
+    if (selected === null && triggerRef.current) {
+      triggerRef.current.focus()
+    }
+  }, [selected])
+
+  // Fokusfelle: Tab-tasten sirkler inni lightboxen
+  useEffect(() => {
+    if (selected === null || !lightboxRef.current) return
+    const el = lightboxRef.current
+    const focusable = el.querySelectorAll('button')
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+
+    const trapFocus = (e) => {
+      if (e.key !== 'Tab') return
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    el.addEventListener('keydown', trapFocus)
+    return () => el.removeEventListener('keydown', trapFocus)
+  }, [selected])
 
   const prev = useCallback(() => {
     setSelected(i => (i - 1 + images.length) % images.length)
@@ -56,11 +99,12 @@ export default function GalleryPage() {
         canonicalPath="/gallery"
       />
       <Nav />
+      <main id="main-content">
       <section className={styles.galleryPage}>
-        <h2>Gallery</h2>
+        <h1>Gallery</h1>
 
         {loading ? (
-          <div className="events-spinner" />
+          <div role="status" aria-label="Laster bilder"><div className="events-spinner" /></div>
         ) : (
           <>
             <div className={styles.galleryGrid}>
@@ -68,8 +112,8 @@ export default function GalleryPage() {
                 <button
                   key={img.id}
                   className={styles.galleryItem}
-                  onClick={() => setSelected(i)}
-                  aria-label={`Open photo ${i + 1}`}
+                  onClick={(e) => { triggerRef.current = e.currentTarget; setSelected(i) }}
+                  aria-label={`Åpne bilde ${i + 1}`}
                 >
                   <img src={getUrl(img.storage_path)} alt={img.alt} loading="lazy" />
                 </button>
@@ -82,15 +126,28 @@ export default function GalleryPage() {
           </>
         )}
       </section>
+      </main>
       <Footer />
 
       {selected !== null && (
-        <div className={styles.lightbox} onClick={close}>
-          <button className={styles.lightboxClose} onClick={close} aria-label="Close">✕</button>
+        <div
+          ref={lightboxRef}
+          className={styles.lightbox}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Bilde ${selected + 1} av ${images.length}`}
+          onClick={close}
+        >
+          <button
+            ref={closeButtonRef}
+            className={styles.lightboxClose}
+            onClick={close}
+            aria-label="Lukk bildevisning"
+          >✕</button>
           <button
             className={styles.lightboxPrev}
             onClick={(e) => { e.stopPropagation(); prev() }}
-            aria-label="Previous"
+            aria-label="Forrige bilde"
           >‹</button>
           <div className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
             <img src={getUrl(images[selected].storage_path)} alt={images[selected].alt} />
@@ -98,7 +155,7 @@ export default function GalleryPage() {
           <button
             className={styles.lightboxNext}
             onClick={(e) => { e.stopPropagation(); next() }}
-            aria-label="Next"
+            aria-label="Neste bilde"
           >›</button>
         </div>
       )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -32,8 +32,11 @@ export default function Home() {
         <script type="application/ld+json">{JSON.stringify(MUSIC_GROUP_SCHEMA)}</script>
       </Helmet>
       <Nav />
-      <Header />
-      <SocialMedia />
+      <main id="main-content">
+        <h1 className="sr-only">Shine On You</h1>
+        <Header />
+        <SocialMedia />
+      </main>
       <Footer />
     </div>
   )

--- a/src/pages/TourPage.jsx
+++ b/src/pages/TourPage.jsx
@@ -12,7 +12,9 @@ export default function TourPage() {
         canonicalPath="/tour"
       />
       <Nav />
-      <Events />
+      <main id="main-content">
+        <Events />
+      </main>
       <Footer />
     </div>
   )

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useAuth } from '../../contexts/AuthContext'
 import EventTable from './EventTable'
 import AboutEditor from './AboutEditor'
@@ -22,6 +22,21 @@ const TABS = [
 export default function AdminDashboard() {
   const { signOut } = useAuth()
   const [activeTab, setActiveTab] = useState('events')
+  const tabRefs = useRef([])
+
+  const handleTabKeyDown = (e, index) => {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      const next = (index + 1) % TABS.length
+      setActiveTab(TABS[next].id)
+      tabRefs.current[next]?.focus()
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const prev = (index - 1 + TABS.length) % TABS.length
+      setActiveTab(TABS[prev].id)
+      tabRefs.current[prev]?.focus()
+    }
+  }
 
   return (
     <div className={styles.adminDashboard}>
@@ -30,19 +45,31 @@ export default function AdminDashboard() {
         <button className={styles.adminSignout} onClick={signOut}>Logg ut</button>
       </div>
 
-      <nav className={styles.adminTabs}>
-        {TABS.map((tab) => (
+      <div className={styles.adminTabs} role="tablist" aria-label="Admin seksjoner">
+        {TABS.map((tab, i) => (
           <button
             key={tab.id}
+            ref={el => { tabRefs.current[i] = el }}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`tabpanel-${tab.id}`}
+            id={`tab-${tab.id}`}
+            tabIndex={activeTab === tab.id ? 0 : -1}
             className={`${styles.adminTab} ${activeTab === tab.id ? styles.adminTabActive : ''}`}
             onClick={() => setActiveTab(tab.id)}
+            onKeyDown={(e) => handleTabKeyDown(e, i)}
           >
             {tab.label}
           </button>
         ))}
-      </nav>
+      </div>
 
-      <div className={styles.adminContent}>
+      <div
+        role="tabpanel"
+        id={`tabpanel-${activeTab}`}
+        aria-labelledby={`tab-${activeTab}`}
+        className={styles.adminContent}
+      >
         {activeTab === 'events' && <EventTable />}
         {activeTab === 'about' && <AboutEditor />}
         {activeTab === 'members' && <BandMembersManager />}

--- a/src/pages/admin/AdminLogin.jsx
+++ b/src/pages/admin/AdminLogin.jsx
@@ -28,14 +28,18 @@ export default function AdminLogin() {
     <div className={styles.adminLogin}>
       <h1>Admin</h1>
       <form onSubmit={handleSubmit}>
+        <label htmlFor="login-email" className={styles.adminLabel}>E-post</label>
         <input
+          id="login-email"
           type="email"
           placeholder="E-post"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
         />
+        <label htmlFor="login-password" className={styles.adminLabel}>Passord</label>
         <input
+          id="login-password"
           type="password"
           placeholder="Passord"
           value={password}

--- a/src/pages/admin/AdminLogin.module.css
+++ b/src/pages/admin/AdminLogin.module.css
@@ -19,6 +19,12 @@
   width: 320px;
 }
 
+.adminLabel {
+  font-size: 13px;
+  color: #aaa;
+  margin-bottom: -4px;
+}
+
 .adminLogin input {
   padding: 10px;
   border-radius: 6px;


### PR DESCRIPTION
- h1 på alle offentlige sider (Home sr-only, About/Gallery/Tour synlig)
- main-landmark med id="main-content" på alle sider
- Skip-to-content lenke i navigasjon (synlig ved tastaturfokus)
- :focus-visible outline globalt for tastaturbrukere
- .sr-only utility-klasse i index.css
- Lightbox: role=dialog, aria-modal, fokusfelle og fokushåndtering (åpne/lukk)
- Loading-spinnere: role=status og aria-label
- AdminLogin: label-elementer koblet til inputs
- AdminDashboard: role=tablist/tab/tabpanel, aria-selected, piltastnavigasjon
- Fix pre-eksisterende testfeil i Events.test.jsx