### PR TITLE
Add Videos page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Home from './pages/Home'
 import AboutPage from './pages/AboutPage'
 import GalleryPage from './pages/GalleryPage'
 import TourPage from './pages/TourPage'
+import VideosPage from './pages/VideosPage'
 import AdminLogin from './pages/admin/AdminLogin'
 import AdminDashboard from './pages/admin/AdminDashboard'
 
@@ -17,6 +18,7 @@ export default function App() {
           <Route path="/about" element={<AboutPage />} />
           <Route path="/gallery" element={<GalleryPage />} />
           <Route path="/tour" element={<TourPage />} />
+          <Route path="/videos" element={<VideosPage />} />
           <Route path="/admin/login" element={<AdminLogin />} />
           <Route
             path="/admin"

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -11,6 +11,7 @@ export default function Nav() {
           <li><NavLink to="/tour">Tour</NavLink></li>
           <li><NavLink to="/about">About</NavLink></li>
           <li><NavLink to="/gallery">Gallery</NavLink></li>
+          <li><NavLink to="/videos">Videos</NavLink></li>
         </ul>
       </nav>
     </>

--- a/src/pages/VideosPage.jsx
+++ b/src/pages/VideosPage.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import Nav from '../components/Nav'
+import Footer from '../components/Footer'
+import { supabase } from '../lib/supabase'
+import SEO from '../components/SEO'
+import styles from './VideosPage.module.css'
+
+export default function VideosPage() {
+  const [videos, setVideos] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    supabase.from('videos').select('*').order('sort_order').then(({ data }) => {
+      setVideos(data ?? [])
+      setLoading(false)
+    })
+  }, [])
+
+  return (
+    <div className="container">
+      <SEO
+        title="Videos – Shine On You Pink Floyd Tribute"
+        description="Se videoer fra Shine On You, Norges fremste Pink Floyd-tributeband."
+        canonicalPath="/videos"
+      />
+      <Nav />
+      <main id="main-content">
+        <section className={styles.videosPage}>
+          <h1>Videos</h1>
+
+          {loading ? (
+            <div role="status" aria-label="Laster videoer"><div className="events-spinner" /></div>
+          ) : videos.length === 0 ? (
+            <p className={styles.empty}>No videos have been added yet.</p>
+          ) : (
+            <div className={styles.videoGrid}>
+              {videos.map((v) => (
+                <div key={v.id} className={styles.videoItem}>
+                  <div className={styles.embedWrapper}>
+                    <iframe
+                      src={`https://www.youtube.com/embed/${v.youtube_id}`}
+                      title={v.title || `Video ${v.youtube_id}`}
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                    />
+                  </div>
+                  {v.title && <p className={styles.videoTitle}>{v.title}</p>}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/pages/VideosPage.module.css
+++ b/src/pages/VideosPage.module.css
@@ -1,0 +1,51 @@
+.videosPage {
+  color: #fff;
+  padding: 20px;
+}
+
+.videosPage h1 {
+  margin-bottom: 32px;
+}
+
+.videoGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 40px;
+}
+
+@media (min-width: 640px) {
+  .videoGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.videoItem {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.embedWrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+
+.embedWrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 4px;
+}
+
+.videoTitle {
+  font-size: 15px;
+  color: #ccc;
+  margin: 0;
+}
+
+.empty {
+  color: #888;
+}

--- a/src/pages/admin/AdminShared.module.css
+++ b/src/pages/admin/AdminShared.module.css
@@ -134,6 +134,12 @@
   background: #1e1e1e;
   padding: 10px 14px;
   border-radius: 6px;
+  cursor: grab;
+}
+
+.videoDragOver {
+  outline: 2px dashed #e63946;
+  opacity: 0.7;
 }
 
 .videoItem span,

--- a/src/pages/admin/VideoManager.jsx
+++ b/src/pages/admin/VideoManager.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { supabase } from '../../lib/supabase'
 import shared from './AdminShared.module.css'
 
@@ -7,6 +7,8 @@ export default function VideoManager() {
   const [youtubeId, setYoutubeId] = useState('')
   const [title, setTitle] = useState('')
   const [adding, setAdding] = useState(false)
+  const [dragOverIndex, setDragOverIndex] = useState(null)
+  const dragIndexRef = useRef(null)
 
   const fetch = async () => {
     const { data } = await supabase.from('videos').select('*').order('sort_order')
@@ -29,6 +31,43 @@ export default function VideoManager() {
     if (!window.confirm('Slette denne videoen?')) return
     await supabase.from('videos').delete().eq('id', id)
     fetch()
+  }
+
+  const handleDragStart = (index) => {
+    dragIndexRef.current = index
+  }
+
+  const handleDragOver = (e, index) => {
+    e.preventDefault()
+    setDragOverIndex(index)
+  }
+
+  const handleDrop = async (e, dropIndex) => {
+    e.preventDefault()
+    const dragIndex = dragIndexRef.current
+    if (dragIndex === null || dragIndex === dropIndex) {
+      setDragOverIndex(null)
+      return
+    }
+
+    const reordered = [...videos]
+    const [moved] = reordered.splice(dragIndex, 1)
+    reordered.splice(dropIndex, 0, moved)
+
+    setVideos(reordered)
+    setDragOverIndex(null)
+    dragIndexRef.current = null
+
+    await Promise.all(
+      reordered.map((v, i) =>
+        supabase.from('videos').update({ sort_order: i }).eq('id', v.id)
+      )
+    )
+  }
+
+  const handleDragEnd = () => {
+    setDragOverIndex(null)
+    dragIndexRef.current = null
   }
 
   return (
@@ -54,8 +93,17 @@ export default function VideoManager() {
       </form>
 
       <div className={shared.videoList}>
-        {videos.map((v) => (
-          <div key={v.id} className={shared.videoItem}>
+        {videos.map((v, i) => (
+          <div
+            key={v.id}
+            className={`${shared.videoItem}${dragOverIndex === i ? ` ${shared.videoDragOver}` : ''}`}
+            draggable
+            onDragStart={() => handleDragStart(i)}
+            onDragOver={(e) => handleDragOver(e, i)}
+            onDrop={(e) => handleDrop(e, i)}
+            onDragEnd={handleDragEnd}
+          >
+            <span>⠿</span>
             <span>{v.title || v.youtube_id}</span>
             <a href={`https://www.youtube.com/watch?v=${v.youtube_id}`} target="_blank" rel="noreferrer">Se</a>
             <button onClick={() => handleDelete(v.id)}>Slett</button>


### PR DESCRIPTION
## Summary
- New public `/videos` page displaying YouTube embeds from Supabase `videos` table
- Responsive 2-column grid layout (1 column on mobile)
- "Videos" nav link added last in navigation
- Admin `VideoManager` enhanced with drag-to-reorder so sort order is actually controllable

## Test plan
- [ ] Naviger til `/videos` og verifiser at videoer vises med korrekt tittel
- [ ] Legg til en video i `/admin` → "Videoer"-fanen og sjekk at den dukker opp
- [ ] Dra-og-slipp videoer i admin for å endre rekkefølge, verifiser at rekkefølgen reflekteres på `/videos`
- [ ] Sjekk responsivt layout på mobil og desktop
- [ ] Sjekk at "Videos"-lenken i nav markeres som aktiv

🤖 Generated with [Claude Code](https://claude.com/claude-code)