### PR TITLE
Translate Norwegian aria-labels to English

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -70,7 +70,7 @@ export default function Events() {
 
   if (loading) return (
     <section id="events" className={styles.upcomingEvents}>
-      <div role="status" aria-label="Laster konserter">
+      <div role="status" aria-label="Loading shows">
         <div className="events-spinner" />
       </div>
     </section>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -4,7 +4,7 @@ import styles from './Nav.module.css'
 export default function Nav() {
   return (
     <>
-      <a href="#main-content" className={styles.skipLink}>Hopp til innhold</a>
+      <a href="#main-content" className={styles.skipLink}>Skip to content</a>
       <nav className={styles.mainNav}>
         <ul className={styles.navLinks}>
           <li><NavLink to="/">Home</NavLink></li>

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -39,7 +39,7 @@ export default function AboutPage() {
         <h1>About</h1>
         <div className={styles.aboutBio}>
           {loading
-            ? <div role="status" aria-label="Laster innhold"><div className="events-spinner" /></div>
+            ? <div role="status" aria-label="Loading content"><div className="events-spinner" /></div>
             : paragraphs.map((para, i) => (
                 <p key={i} className={i === 0 ? styles.aboutTagline : undefined}>{para}</p>
               ))

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -104,7 +104,7 @@ export default function GalleryPage() {
         <h1>Gallery</h1>
 
         {loading ? (
-          <div role="status" aria-label="Laster bilder"><div className="events-spinner" /></div>
+          <div role="status" aria-label="Loading images"><div className="events-spinner" /></div>
         ) : (
           <>
             <div className={styles.galleryGrid}>
@@ -113,7 +113,7 @@ export default function GalleryPage() {
                   key={img.id}
                   className={styles.galleryItem}
                   onClick={(e) => { triggerRef.current = e.currentTarget; setSelected(i) }}
-                  aria-label={`Åpne bilde ${i + 1}`}
+                  aria-label={`Open image ${i + 1}`}
                 >
                   <img src={getUrl(img.storage_path)} alt={img.alt} loading="lazy" />
                 </button>
@@ -135,19 +135,19 @@ export default function GalleryPage() {
           className={styles.lightbox}
           role="dialog"
           aria-modal="true"
-          aria-label={`Bilde ${selected + 1} av ${images.length}`}
+          aria-label={`Image ${selected + 1} of ${images.length}`}
           onClick={close}
         >
           <button
             ref={closeButtonRef}
             className={styles.lightboxClose}
             onClick={close}
-            aria-label="Lukk bildevisning"
+            aria-label="Close gallery"
           >✕</button>
           <button
             className={styles.lightboxPrev}
             onClick={(e) => { e.stopPropagation(); prev() }}
-            aria-label="Forrige bilde"
+            aria-label="Previous image"
           >‹</button>
           <div className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
             <img src={getUrl(images[selected].storage_path)} alt={images[selected].alt} />
@@ -155,7 +155,7 @@ export default function GalleryPage() {
           <button
             className={styles.lightboxNext}
             onClick={(e) => { e.stopPropagation(); next() }}
-            aria-label="Neste bilde"
+            aria-label="Next image"
           >›</button>
         </div>
       )}

--- a/src/pages/VideosPage.jsx
+++ b/src/pages/VideosPage.jsx
@@ -29,7 +29,7 @@ export default function VideosPage() {
           <h1>Videos</h1>
 
           {loading ? (
-            <div role="status" aria-label="Laster videoer"><div className="events-spinner" /></div>
+            <div role="status" aria-label="Loading videos"><div className="events-spinner" /></div>
           ) : videos.length === 0 ? (
             <p className={styles.empty}>No videos have been added yet.</p>
           ) : (


### PR DESCRIPTION
## Summary
Translates all Norwegian accessibility strings to English for consistency with the rest of the site.

| File | Norwegian → English |
|------|---------------------|
| `Nav.jsx` | "Hopp til innhold" → "Skip to content" |
| `AboutPage.jsx` | "Laster innhold" → "Loading content" |
| `Events.jsx` | "Laster konserter" → "Loading shows" |
| `GalleryPage.jsx` | "Laster bilder" → "Loading images" |
| `GalleryPage.jsx` | "Åpne bilde {n}" → "Open image {n}" |
| `GalleryPage.jsx` | "Bilde {x} av {y}" → "Image {x} of {y}" |
| `GalleryPage.jsx` | "Lukk bildevisning" → "Close gallery" |
| `GalleryPage.jsx` | "Forrige bilde" → "Previous image" |
| `GalleryPage.jsx` | "Neste bilde" → "Next image" |
| `VideosPage.jsx` | "Laster videoer" → "Loading videos" |

## Test plan
- [ ] Verifiser skip-link tekst i Nav ("Skip to content")
- [ ] Test med skjermleser eller browser accessibility inspector at aria-labels er oppdatert

🤖 Generated with [Claude Code](https://claude.com/claude-code)