### PR TITLE
Move social media links to Supabase settings

### DIFF
--- a/src/components/SocialMedia.jsx
+++ b/src/components/SocialMedia.jsx
@@ -1,31 +1,50 @@
+import { useEffect, useState } from 'react'
 import { FaFacebookF, FaInstagram, FaYoutube } from 'react-icons/fa'
+import { supabase } from '../lib/supabase'
 import styles from './SocialMedia.module.css'
 
 export default function SocialMedia() {
+  const [links, setLinks] = useState({ facebook_url: '', instagram_url: '', youtube_url: '' })
+
+  useEffect(() => {
+    supabase
+      .from('settings')
+      .select('facebook_url, instagram_url, youtube_url')
+      .eq('id', 1)
+      .single()
+      .then(({ data }) => { if (data) setLinks(data) })
+  }, [])
+
   return (
     <section id="social-media" className={styles.socialMedia}>
       <div className={styles.socialIcons}>
-        <a
-          href="https://www.facebook.com/ShineOnU21"
-          className={styles.facebook}
-          aria-label="Visit our Facebook page"
-        >
-          <FaFacebookF size={32} />
-        </a>
-        <a
-          href="https://www.instagram.com/shineonyou_official/"
-          className={styles.instagram}
-          aria-label="Visit our Instagram page"
-        >
-          <FaInstagram size={32} />
-        </a>
-        <a
-          href="https://www.youtube.com/@shineonyou-gq7uc"
-          className={styles.youtube}
-          aria-label="Visit our Youtube page"
-        >
-          <FaYoutube size={32} />
-        </a>
+        {links.facebook_url && (
+          <a
+            href={links.facebook_url}
+            className={styles.facebook}
+            aria-label="Visit our Facebook page"
+          >
+            <FaFacebookF size={32} />
+          </a>
+        )}
+        {links.instagram_url && (
+          <a
+            href={links.instagram_url}
+            className={styles.instagram}
+            aria-label="Visit our Instagram page"
+          >
+            <FaInstagram size={32} />
+          </a>
+        )}
+        {links.youtube_url && (
+          <a
+            href={links.youtube_url}
+            className={styles.youtube}
+            aria-label="Visit our Youtube page"
+          >
+            <FaYoutube size={32} />
+          </a>
+        )}
       </div>
     </section>
   )

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,13 @@
+import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 import Nav from '../components/Nav'
 import Header from '../components/Header'
 import SocialMedia from '../components/SocialMedia'
 import Footer from '../components/Footer'
 import SEO from '../components/SEO'
+import { supabase } from '../lib/supabase'
 
-const MUSIC_GROUP_SCHEMA = {
+const BASE_SCHEMA = {
   '@context': 'https://schema.org',
   '@type': 'MusicGroup',
   name: 'Shine On You',
@@ -13,14 +15,26 @@ const MUSIC_GROUP_SCHEMA = {
   url: 'https://shineonyou.no',
   genre: 'Rock',
   foundingLocation: { '@type': 'Place', name: 'Norway' },
-  sameAs: [
-    'https://www.facebook.com/ShineOnU21',
-    'https://www.instagram.com/shineonyou_official/',
-    'https://www.youtube.com/@shineonyou-gq7uc',
-  ],
 }
 
 export default function Home() {
+  const [sameAs, setSameAs] = useState([])
+
+  useEffect(() => {
+    supabase
+      .from('settings')
+      .select('facebook_url, instagram_url, youtube_url')
+      .eq('id', 1)
+      .single()
+      .then(({ data }) => {
+        if (data) {
+          setSameAs([data.facebook_url, data.instagram_url, data.youtube_url].filter(Boolean))
+        }
+      })
+  }, [])
+
+  const schema = { ...BASE_SCHEMA, sameAs }
+
   return (
     <div className="container">
       <SEO
@@ -29,7 +43,7 @@ export default function Home() {
         canonicalPath="/"
       />
       <Helmet>
-        <script type="application/ld+json">{JSON.stringify(MUSIC_GROUP_SCHEMA)}</script>
+        <script type="application/ld+json">{JSON.stringify(schema)}</script>
       </Helmet>
       <Nav />
       <main id="main-content">

--- a/src/pages/admin/SiteSettingsEditor.jsx
+++ b/src/pages/admin/SiteSettingsEditor.jsx
@@ -6,13 +6,16 @@ export default function SiteSettingsEditor() {
   const [tourHeading, setTourHeading] = useState('')
   const [pastShowsHeading, setPastShowsHeading] = useState('')
   const [galleryCredit, setGalleryCredit] = useState('')
+  const [facebookUrl, setFacebookUrl] = useState('')
+  const [instagramUrl, setInstagramUrl] = useState('')
+  const [youtubeUrl, setYoutubeUrl] = useState('')
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
 
   useEffect(() => {
     supabase
       .from('settings')
-      .select('tour_heading, past_shows_heading, gallery_photo_credit')
+      .select('tour_heading, past_shows_heading, gallery_photo_credit, facebook_url, instagram_url, youtube_url')
       .eq('id', 1)
       .single()
       .then(({ data }) => {
@@ -20,6 +23,9 @@ export default function SiteSettingsEditor() {
           setTourHeading(data.tour_heading)
           setPastShowsHeading(data.past_shows_heading)
           setGalleryCredit(data.gallery_photo_credit ?? '')
+          setFacebookUrl(data.facebook_url ?? '')
+          setInstagramUrl(data.instagram_url ?? '')
+          setYoutubeUrl(data.youtube_url ?? '')
         }
       })
   }, [])
@@ -32,6 +38,9 @@ export default function SiteSettingsEditor() {
         tour_heading: tourHeading,
         past_shows_heading: pastShowsHeading,
         gallery_photo_credit: galleryCredit,
+        facebook_url: facebookUrl,
+        instagram_url: instagramUrl,
+        youtube_url: youtubeUrl,
         updated_at: new Date().toISOString(),
       })
       .eq('id', 1)
@@ -67,6 +76,33 @@ export default function SiteSettingsEditor() {
           value={galleryCredit}
           onChange={(e) => setGalleryCredit(e.target.value)}
           placeholder="Espen Håkonsen, Patrik Skiffard"
+        />
+      </div>
+      <div className={shared.formRow}>
+        <label>Facebook URL</label>
+        <input
+          type="url"
+          value={facebookUrl}
+          onChange={(e) => setFacebookUrl(e.target.value)}
+          placeholder="https://www.facebook.com/..."
+        />
+      </div>
+      <div className={shared.formRow}>
+        <label>Instagram URL</label>
+        <input
+          type="url"
+          value={instagramUrl}
+          onChange={(e) => setInstagramUrl(e.target.value)}
+          placeholder="https://www.instagram.com/..."
+        />
+      </div>
+      <div className={shared.formRow}>
+        <label>YouTube URL</label>
+        <input
+          type="url"
+          value={youtubeUrl}
+          onChange={(e) => setYoutubeUrl(e.target.value)}
+          placeholder="https://www.youtube.com/..."
         />
       </div>
       <button onClick={handleSave} disabled={saving}>


### PR DESCRIPTION
## Summary

- Adds `facebook_url`, `instagram_url`, `youtube_url` columns to the `settings` table (migration must be run in Supabase SQL Editor — see below)
- `SocialMedia.jsx` fetches URLs dynamically from Supabase instead of hardcoding them
- `Home.jsx` builds `sameAs` in schema.org JSON-LD dynamically from the same data
- `SiteSettingsEditor.jsx` exposes three new URL fields in admin → Innstillinger

## Supabase migration

```sql
ALTER TABLE settings
  ADD COLUMN facebook_url text,
  ADD COLUMN instagram_url text,
  ADD COLUMN youtube_url text;

UPDATE settings SET
  facebook_url = 'https://www.facebook.com/ShineOnU21',
  instagram_url = 'https://www.instagram.com/shineonyou_official/',
  youtube_url = 'https://www.youtube.com/@shineonyou-gq7uc'
WHERE id = 1;
```

## Test plan

- [ ] Admin → Innstillinger: tre nye URL-felt vises med eksisterende verdier
- [ ] Lagre endrede verdier — bekreft at `settings`-raden oppdateres i Supabase
- [ ] Forside: social media-ikoner peker på riktige URLer
- [ ] Inspisér `<script type="application/ld+json">` i DOM — `sameAs` er dynamisk

🤖 Generated with [Claude Code](https://claude.com/claude-code)