### PR TITLE
Add audit logging for admin panel changes

### DIFF
--- a/src/lib/auditStorage.js
+++ b/src/lib/auditStorage.js
@@ -1,0 +1,23 @@
+import { supabase } from './supabase'
+
+async function writeStorageAudit(operation, bucket, path) {
+  await supabase.from('audit_log').insert({
+    table_name: `storage:${bucket}`,
+    operation,
+    record_id: path,
+    old_data: null,
+    new_data: null,
+  })
+}
+
+export async function storageUpload(bucket, path, file, options = {}) {
+  const result = await supabase.storage.from(bucket).upload(path, file, options)
+  if (!result.error) writeStorageAudit('STORAGE_UPLOAD', bucket, path)
+  return result
+}
+
+export async function storageRemove(bucket, paths) {
+  const result = await supabase.storage.from(bucket).remove(paths)
+  if (!result.error) paths.forEach(p => writeStorageAudit('STORAGE_DELETE', bucket, p))
+  return result
+}

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -7,6 +7,7 @@ import GalleryManager from './GalleryManager'
 import PressKitManager from './PressKitManager'
 import SiteSettingsEditor from './SiteSettingsEditor'
 import BandMembersManager from './BandMembersManager'
+import AuditLog from './AuditLog'
 import styles from './AdminDashboard.module.css'
 
 const TABS = [
@@ -17,6 +18,7 @@ const TABS = [
   { id: 'gallery', label: 'Galleri' },
   { id: 'presskit', label: 'Press Kit' },
   { id: 'settings', label: 'Innstillinger' },
+  { id: 'auditlog', label: 'Endringslogg' },
 ]
 
 export default function AdminDashboard() {
@@ -77,6 +79,7 @@ export default function AdminDashboard() {
         {activeTab === 'gallery' && <GalleryManager />}
         {activeTab === 'presskit' && <PressKitManager />}
         {activeTab === 'settings' && <SiteSettingsEditor />}
+        {activeTab === 'auditlog' && <AuditLog />}
       </div>
     </div>
   )

--- a/src/pages/admin/AuditLog.jsx
+++ b/src/pages/admin/AuditLog.jsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useState } from 'react'
+import { supabase } from '../../lib/supabase'
+import shared from './AdminShared.module.css'
+
+const PAGE_SIZE = 50
+
+const TABLE_OPTIONS = [
+  'all', 'events', 'about', 'members', 'videos',
+  'gallery', 'presskit_files', 'settings', 'contact',
+  'storage:gallery', 'storage:members', 'storage:presskit',
+]
+
+const OP_STYLE = {
+  INSERT:         { label: 'Lagt til',   color: '#4caf50' },
+  UPDATE:         { label: 'Endret',     color: '#ff9800' },
+  DELETE:         { label: 'Slettet',    color: '#f44336' },
+  STORAGE_UPLOAD: { label: 'Fil lastet', color: '#2196f3' },
+  STORAGE_DELETE: { label: 'Fil slettet',color: '#9c27b0' },
+}
+
+const formatDate = (iso) =>
+  new Date(iso).toLocaleString('nb-NO', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+
+export default function AuditLog() {
+  const [rows, setRows]               = useState([])
+  const [loading, setLoading]         = useState(true)
+  const [error, setError]             = useState(null)
+  const [tableFilter, setTableFilter] = useState('all')
+  const [page, setPage]               = useState(0)
+  const [hasMore, setHasMore]         = useState(false)
+  const [expanded, setExpanded]       = useState(null)
+
+  const load = useCallback(async (filter, p) => {
+    setLoading(true)
+    setError(null)
+
+    let q = supabase
+      .from('audit_log')
+      .select('id, created_at, user_email, table_name, operation, record_id, old_data, new_data')
+      .order('created_at', { ascending: false })
+      .range(p * PAGE_SIZE, p * PAGE_SIZE + PAGE_SIZE)
+
+    if (filter !== 'all') q = q.eq('table_name', filter)
+
+    const { data, error: err } = await q
+    if (err) {
+      setError('Klarte ikke hente endringslogg.')
+    } else {
+      setHasMore(data.length > PAGE_SIZE)
+      setRows(data.slice(0, PAGE_SIZE))
+    }
+    setLoading(false)
+  }, [])
+
+  useEffect(() => { setPage(0) }, [tableFilter])
+  useEffect(() => { load(tableFilter, page) }, [tableFilter, page, load])
+
+  return (
+    <div className={shared.editor}>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        <label style={{ fontSize: 13, color: '#aaa' }}>Tabell</label>
+        <select
+          value={tableFilter}
+          onChange={e => setTableFilter(e.target.value)}
+          style={{ padding: '6px 10px', borderRadius: 6, background: '#1e1e1e', color: '#fff', border: '1px solid #444' }}
+        >
+          {TABLE_OPTIONS.map(t => (
+            <option key={t} value={t}>{t === 'all' ? 'Alle' : t}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && <p className={shared.error}>{error}</p>}
+      {loading && <p style={{ color: '#aaa' }}>Laster…</p>}
+      {!loading && rows.length === 0 && <p style={{ color: '#aaa' }}>Ingen loggposter funnet.</p>}
+
+      <div className={shared.fileList}>
+        {rows.map(row => {
+          const op = OP_STYLE[row.operation] ?? { label: row.operation, color: '#aaa' }
+          const isExpanded = expanded === row.id
+          const hasDiff = row.old_data || row.new_data
+
+          return (
+            <div
+              key={row.id}
+              className={shared.fileItem}
+              style={{ flexDirection: 'column', alignItems: 'flex-start', cursor: 'default' }}
+            >
+              <div style={{ display: 'flex', gap: 12, width: '100%', alignItems: 'center' }}>
+                <span style={{ color: '#aaa', fontSize: 12, minWidth: 150 }}>
+                  {formatDate(row.created_at)}
+                </span>
+                <span style={{ color: op.color, fontWeight: 600, minWidth: 90, fontSize: 13 }}>
+                  {op.label}
+                </span>
+                <span style={{ flex: 1, fontSize: 13 }}>
+                  <strong>{row.table_name}</strong>
+                  {row.record_id && <span style={{ color: '#aaa' }}> #{row.record_id}</span>}
+                </span>
+                <span style={{ fontSize: 12, color: '#aaa' }}>
+                  {row.user_email ?? '—'}
+                </span>
+                {hasDiff && (
+                  <button
+                    onClick={() => setExpanded(prev => prev === row.id ? null : row.id)}
+                    style={{ background: '#333', color: '#aaa', border: 'none', borderRadius: 4, padding: '2px 8px', cursor: 'pointer', fontSize: 12 }}
+                  >
+                    {isExpanded ? 'Skjul' : 'Diff'}
+                  </button>
+                )}
+              </div>
+
+              {isExpanded && (
+                <div style={{ display: 'flex', gap: 12, width: '100%', marginTop: 8 }}>
+                  {row.old_data && (
+                    <pre style={{ flex: 1, background: '#1a1a1a', border: '1px solid #333', borderRadius: 4, padding: 10, fontSize: 11, color: '#f88', overflow: 'auto', maxHeight: 280, margin: 0 }}>
+                      {JSON.stringify(row.old_data, null, 2)}
+                    </pre>
+                  )}
+                  {row.new_data && (
+                    <pre style={{ flex: 1, background: '#1a1a1a', border: '1px solid #333', borderRadius: 4, padding: 10, fontSize: 11, color: '#8f8', overflow: 'auto', maxHeight: 280, margin: 0 }}>
+                      {JSON.stringify(row.new_data, null, 2)}
+                    </pre>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        <button
+          onClick={() => setPage(p => Math.max(0, p - 1))}
+          disabled={page === 0}
+          style={{ background: '#333', color: '#fff', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: page === 0 ? 'not-allowed' : 'pointer' }}
+        >
+          Forrige
+        </button>
+        <span style={{ color: '#aaa', fontSize: 13 }}>Side {page + 1}</span>
+        <button
+          onClick={() => setPage(p => p + 1)}
+          disabled={!hasMore}
+          style={{ background: '#333', color: '#fff', border: 'none', borderRadius: 6, padding: '6px 14px', cursor: !hasMore ? 'not-allowed' : 'pointer' }}
+        >
+          Neste
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/admin/BandMembersManager.jsx
+++ b/src/pages/admin/BandMembersManager.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { supabase } from '../../lib/supabase'
+import { storageUpload, storageRemove } from '../../lib/auditStorage'
 import shared from './AdminShared.module.css'
 
 export default function BandMembersManager() {
@@ -26,7 +27,7 @@ export default function BandMembersManager() {
 
     const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
     const path = `${Date.now()}-${safeName}`
-    const { error } = await supabase.storage.from('members').upload(path, file)
+    const { error } = await storageUpload('members', path, file)
     if (!error) {
       await supabase.from('members').insert([{
         name: newName.trim(),
@@ -51,7 +52,7 @@ export default function BandMembersManager() {
 
   const handleDelete = async (member) => {
     if (!window.confirm(`Slette ${member.name}?`)) return
-    await supabase.storage.from('members').remove([member.storage_path])
+    await storageRemove('members', [member.storage_path])
     await supabase.from('members').delete().eq('id', member.id)
     fetchMembers()
   }

--- a/src/pages/admin/GalleryManager.jsx
+++ b/src/pages/admin/GalleryManager.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { supabase } from '../../lib/supabase'
+import { storageUpload, storageRemove } from '../../lib/auditStorage'
 import shared from './AdminShared.module.css'
 
 export default function GalleryManager() {
@@ -25,7 +26,7 @@ export default function GalleryManager() {
     for (const file of files) {
       const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
       const path = `${Date.now()}-${safeName}`
-      const { error } = await supabase.storage.from('gallery').upload(path, file)
+      const { error } = await storageUpload('gallery', path, file)
       if (!error) {
         await supabase.from('gallery').insert([{
           storage_path: path,
@@ -42,7 +43,7 @@ export default function GalleryManager() {
 
   const handleDelete = async (image) => {
     if (!window.confirm('Slette dette bildet?')) return
-    await supabase.storage.from('gallery').remove([image.storage_path])
+    await storageRemove('gallery', [image.storage_path])
     await supabase.from('gallery').delete().eq('id', image.id)
     fetchImages()
   }

--- a/src/pages/admin/PressKitManager.jsx
+++ b/src/pages/admin/PressKitManager.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { supabase } from '../../lib/supabase'
+import { storageUpload, storageRemove } from '../../lib/auditStorage'
 import shared from './AdminShared.module.css'
 
 export default function PressKitManager() {
@@ -21,7 +22,7 @@ export default function PressKitManager() {
     setUploading(true)
 
     const path = `${Date.now()}-${file.name}`
-    const { error } = await supabase.storage.from('presskit').upload(path, file)
+    const { error } = await storageUpload('presskit', path, file)
     if (!error) {
       await supabase.from('presskit_files').insert([{ label: label.trim(), storage_path: path }])
     }
@@ -34,7 +35,7 @@ export default function PressKitManager() {
 
   const handleDelete = async (item) => {
     if (!window.confirm(`Slette "${item.label}"?`)) return
-    await supabase.storage.from('presskit').remove([item.storage_path])
+    await storageRemove('presskit', [item.storage_path])
     await supabase.from('presskit_files').delete().eq('id', item.id)
     fetch()
   }


### PR DESCRIPTION
## Summary

- Adds `audit_log` table + PostgreSQL triggers (SECURITY DEFINER) on all 8 tables — automatically logs INSERT/UPDATE/DELETE with user email and before/after data
- Adds `src/lib/auditStorage.js` helper to log storage file uploads/deletes (triggers can't catch these)
- Adds new **Endringslogg** tab in admin panel with filter by table, diff view (old/red, new/green), and pagination

## Database migration required

Run the SQL in the plan file (`~/.claude/plans/n-har-jeg-sendt-shimmying-adleman.md`) in Supabase SQL Editor — already done in production.

## Test plan

- [ ] Log in to admin panel and make a change (e.g. save a setting)
- [ ] Open Endringslogg tab — verify a row appears with correct user email, table, and diff
- [ ] Upload/delete a file in Gallery or Press Kit — verify `storage:*` row appears in log
- [ ] Test filter dropdown — verify filtering by table works correctly
- [ ] Test pagination with 50+ log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)