### PR TITLE
Block /tourledger from search engine indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /tourledger
+Disallow: /tourledger/
 
 Sitemap: https://shineonyou.no/sitemap.xml


### PR DESCRIPTION
## Summary
- Adds `Disallow: /tourledger` and `Disallow: /tourledger/` to `robots.txt`

## Why
tourledger er en intern app på samme domene som ikke skal indekseres av Google.