### PR TITLE
Add History section for past shows

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -19,7 +19,7 @@ function EventCard({ event, past }) {
   const year = d.getFullYear()
 
   return (
-    <div className={`${styles.event}${past ? ` ${styles.eventPast}` : ''}`}>
+    <div className={styles.event}>
       <div className={styles.eventDateBlock}>
         <span className={styles.eventDay}>{day}</span>
         <span className={styles.eventMonth}>{month}</span>
@@ -31,9 +31,11 @@ function EventCard({ event, past }) {
             <span className={styles.eventCity}>{event.city}, {event.country}</span>
             <span className={styles.eventVenue}>{event.venue}</span>
           </div>
-          <div className={styles.tickets}>
-            <TicketLabel event={event} />
-          </div>
+          {!past && (
+            <div className={styles.tickets}>
+              <TicketLabel event={event} />
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -43,7 +45,7 @@ function EventCard({ event, past }) {
 export default function Events() {
   const [upcoming, setUpcoming] = useState([])
   const [past, setPast] = useState([])
-  const [settings, setSettings] = useState({ tour_heading: 'Tour 2026', past_shows_heading: 'Past shows 2026' })
+  const [settings, setSettings] = useState({ tour_heading: 'Tour 2026', past_shows_heading: 'Past shows' })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
@@ -58,8 +60,8 @@ export default function Events() {
       if (error) {
         setError(true)
       } else if (data) {
-        setUpcoming(data.filter((e) => e.date >= today))
-        setPast(data.filter((e) => e.date < today).reverse())
+        setUpcoming(data.filter((e) => e.date >= today && !e.is_history))
+        setPast(data.filter((e) => e.date < today || e.is_history).reverse())
       }
       if (settingsData) setSettings(settingsData)
       setLoading(false)

--- a/src/components/Events.module.css
+++ b/src/components/Events.module.css
@@ -19,10 +19,6 @@
   border-bottom: 1px solid #2e2e2e;
 }
 
-.eventPast {
-  opacity: 0.45;
-  margin-bottom: 88px;
-}
 
 .eventDateBlock {
   display: flex;
@@ -49,7 +45,7 @@
 
 .eventYear {
   font-size: 13px;
-  color: #555;
+  color: #fff;
   letter-spacing: 0.08em;
 }
 

--- a/src/pages/admin/EventForm.jsx
+++ b/src/pages/admin/EventForm.jsx
@@ -8,6 +8,7 @@ const EMPTY = {
   country: '',
   ticket_url: '',
   ticket_status: 'available',
+  is_history: false,
 }
 
 export default function EventForm({ initial, onSave, onCancel }) {
@@ -52,6 +53,16 @@ export default function EventForm({ initial, onSave, onCancel }) {
           <option value="coming_soon">Coming Soon</option>
           <option value="sold_out">Sold Out</option>
         </select>
+      </div>
+      <div className={shared.formRow}>
+        <label>
+          <input
+            type="checkbox"
+            checked={!!form.is_history}
+            onChange={(e) => setForm((f) => ({ ...f, is_history: e.target.checked }))}
+          />
+          {' '}Flytt til History (Past shows)
+        </label>
       </div>
       <div className={shared.formActions}>
         <button type="submit" disabled={saving}>{saving ? 'Lagrer…' : 'Lagre'}</button>

--- a/src/pages/admin/EventTable.jsx
+++ b/src/pages/admin/EventTable.jsx
@@ -76,7 +76,7 @@ export default function EventTable() {
               <td>{e.venue}</td>
               <td>{e.city}</td>
               <td>{e.country}</td>
-              <td>{e.ticket_status}</td>
+              <td>{e.is_history ? 'HISTORY' : e.ticket_status}</td>
               <td>
                 <button onClick={() => setEditing(e)}>Rediger</button>
                 <button onClick={() => handleDelete(e.id)}>Slett</button>


### PR DESCRIPTION
## Summary

- Past shows vises nå med samme styling som kommende shows (fjernet opacity-dimming)
- Tickets-seksjonen skjules for past shows
- Ny `is_history`-toggle i admin for å manuelt flytte et show til Past shows uavhengig av dato
- `eventYear` er nå hvit for bedre lesbarhet
- Fallback-overskrift for past shows oppdatert til "Past shows" (uten årstall)

## Supabase-migrering (må kjøres manuelt)

```sql
ALTER TABLE events ADD COLUMN is_history boolean NOT NULL DEFAULT false;
```

## Admin

Etter migrering: gå til **Innstillinger** og endre `past_shows_heading` fra "Past shows 2026" til "Past shows".

## Test plan

- [ ] Kjør SQL-migrering i Supabase
- [ ] Verifiser at eksisterende past shows vises uten tickets
- [ ] Legg til et show med `is_history = true` og bekreft det havner i Past shows
- [ ] Verifiser at årstallet på shows er hvitt og lesbart
- [ ] Oppdater overskrift i admin-innstillinger

🤖 Generated with [Claude Code](https://claude.com/claude-code)