### PR TITLE
Sort events descending in admin panel

### DIFF
--- a/src/components/Events.module.css
+++ b/src/components/Events.module.css
@@ -135,6 +135,11 @@
     gap: 12px;
   }
 
+  .eventInfo {
+    flex-direction: column;
+    gap: 4px;
+  }
+
   .eventVenue,
   .eventCity {
     font-size: 16px;

--- a/src/pages/admin/EventTable.jsx
+++ b/src/pages/admin/EventTable.jsx
@@ -11,7 +11,7 @@ export default function EventTable() {
   const [saveError, setSaveError] = useState(null)
 
   const fetch = async () => {
-    const { data, error } = await supabase.from('events').select('*').order('date')
+    const { data, error } = await supabase.from('events').select('*').order('date', { ascending: false })
     if (error) setFetchError('Klarte ikke hente arrangementer.')
     else setEvents(data ?? [])
   }


### PR DESCRIPTION
## Summary
- Events i admin-panelet sorteres nå synkende på dato — nyeste event øverst

## Test plan
- [ ] Åpne /admin → Events-fanen og verifiser at nyeste dato vises øverst

🤖 Generated with [Claude Code](https://claude.com/claude-code)