### PR TITLE
Translate Norwegian meta tags to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Shine On You – Pink Floyd Tribute Band</title>
-    <meta name="description" content="Shine On You er Norges fremste Pink Floyd tributeband. Vi fremfører klassikere fra The Dark Side of the Moon, The Wall og Wish You Were Here live i Norge, Sverige og Skandinavia." />
+    <meta name="description" content="Shine On You is Norway's premier Pink Floyd tribute band. Performing classics from The Dark Side of the Moon, The Wall and Wish You Were Here live in Norway, Sweden and Scandinavia." />
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,0,0" />
     <script defer src="https://cloud.umami.is/script.js" data-website-id="6bda9b9b-037a-4b1a-87af-0341b1e12203"></script>

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -29,8 +29,8 @@ export default function AboutPage() {
   return (
     <div className="container">
       <SEO
-        title="Om bandet – Shine On You Pink Floyd Tribute"
-        description="Lær mer om Shine On You, Pink Floyd tributebandet fra Norge. 10 musikere dedikert til å gjenskape Pink Floyds unike lydlandskap."
+        title="About the Band – Shine On You Pink Floyd Tribute"
+        description="Learn more about Shine On You, the Pink Floyd tribute band from Norway. 10 musicians dedicated to recreating Pink Floyd's unique soundscapes."
         canonicalPath="/about"
       />
       <Nav />

--- a/src/pages/GalleryPage.jsx
+++ b/src/pages/GalleryPage.jsx
@@ -94,8 +94,8 @@ export default function GalleryPage() {
   return (
     <div className="container">
       <SEO
-        title="Bilder – Shine On You Pink Floyd Tribute"
-        description="Fotogalleri fra Shine On You sine konserter og opptredener."
+        title="Gallery – Shine On You Pink Floyd Tribute"
+        description="Photo gallery from Shine On You concerts and performances."
         canonicalPath="/gallery"
       />
       <Nav />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -39,7 +39,7 @@ export default function Home() {
     <div className="container">
       <SEO
         title="Shine On You – Pink Floyd Tribute Band"
-        description="Shine On You er Norges fremste Pink Floyd tributeband. Vi fremfører klassikere fra The Dark Side of the Moon, The Wall og Wish You Were Here live i Norge, Sverige og Skandinavia."
+        description="Shine On You is Norway's premier Pink Floyd tribute band. Performing classics from The Dark Side of the Moon, The Wall and Wish You Were Here live in Norway, Sweden and Scandinavia."
         canonicalPath="/"
       />
       <Helmet>

--- a/src/pages/TourPage.jsx
+++ b/src/pages/TourPage.jsx
@@ -7,8 +7,8 @@ export default function TourPage() {
   return (
     <div className="container">
       <SEO
-        title="Konserter & turné – Shine On You"
-        description="Se kommende konserter med Shine On You. Vi spiller over hele Norge og Sverige – sjekk turné-datoer og kjøp billetter."
+        title="Concerts & Tour – Shine On You"
+        description="See upcoming concerts with Shine On You. We perform all across Norway and Sweden – check tour dates and buy tickets."
         canonicalPath="/tour"
       />
       <Nav />

--- a/src/pages/VideosPage.jsx
+++ b/src/pages/VideosPage.jsx
@@ -20,7 +20,7 @@ export default function VideosPage() {
     <div className="container">
       <SEO
         title="Videos – Shine On You Pink Floyd Tribute"
-        description="Se videoer fra Shine On You, Norges fremste Pink Floyd-tributeband."
+        description="Watch videos from Shine On You, Norway's premier Pink Floyd tribute band."
         canonicalPath="/videos"
       />
       <Nav />


### PR DESCRIPTION
## Summary

- Fixes Norwegian-language page titles showing in Google Search Console for `/about` ("Om bandet"), `/gallery` ("Bilder"), and `/tour` ("Konserter & turné")
- Also translates Norwegian descriptions on all pages including `/`, `/videos`
- Fixes `lang="no"` → `lang="en"` in `index.html`

## Changes (6 files, 10 strings)

| File | Fix |
|------|-----|
| `index.html` | `lang="no"` → `lang="en"`, Norwegian fallback description → English |
| `Home.jsx` | Norwegian description → English |
| `AboutPage.jsx` | "Om bandet…" → "About the Band…", Norwegian description → English |
| `GalleryPage.jsx` | "Bilder…" → "Gallery…", Norwegian description → English |
| `TourPage.jsx` | "Konserter & turné…" → "Concerts & Tour…", Norwegian description → English |
| `VideosPage.jsx` | Norwegian description → English |

## Test plan

- [ ] Run dev server and check `<head>` in DevTools for each page — no Norwegian strings should remain in titles or descriptions
- [ ] Verify Google Search Console re-indexes with English titles over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)