### PR TITLE
Increase spacing between tour list and Past shows heading

### DIFF
--- a/src/components/Events.module.css
+++ b/src/components/Events.module.css
@@ -7,7 +7,7 @@
 }
 
 .pastTourHeading {
-  margin-top: 72px;
+  margin-top: 160px;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Øker `margin-top` på `.pastTourHeading` fra 72px til 160px for bedre luft mellom aktiv tour-liste og "Past shows"-seksjonen

🤖 Generated with [Claude Code](https://claude.com/claude-code)