### PR TITLE
fix: improve JSON-LD schemas (VideoObject uploadDate + MusicEvent fields)

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -58,6 +58,8 @@ export default function Home() {
         '@context': 'https://schema.org',
         '@type': 'MusicEvent',
         name: `Shine On You – ${nextEvent.venue}`,
+        description: `Shine On You live at ${nextEvent.venue} in ${nextEvent.city}. A Pink Floyd tribute concert.`,
+        url: nextEvent.ticket_url || 'https://shineonyou.no/tour',
         startDate: nextEvent.date,
         location: {
           '@type': 'Place',
@@ -69,6 +71,7 @@ export default function Home() {
           },
         },
         performer: { '@type': 'MusicGroup', name: 'Shine On You', url: 'https://shineonyou.no' },
+        organizer: { '@type': 'MusicGroup', name: 'Shine On You', url: 'https://shineonyou.no' },
         eventStatus: 'https://schema.org/EventScheduled',
         eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
         ...(nextEvent.ticket_url && {

--- a/src/pages/TourPage.jsx
+++ b/src/pages/TourPage.jsx
@@ -17,6 +17,8 @@ function buildMusicEventSchema(event) {
     '@context': 'https://schema.org',
     '@type': 'MusicEvent',
     name: `Shine On You – ${event.venue}`,
+    description: `Shine On You live at ${event.venue} in ${event.city}. A Pink Floyd tribute concert.`,
+    url: event.ticket_url || 'https://shineonyou.no/tour',
     startDate: event.date,
     location: {
       '@type': 'Place',
@@ -28,6 +30,11 @@ function buildMusicEventSchema(event) {
       },
     },
     performer: {
+      '@type': 'MusicGroup',
+      name: 'Shine On You',
+      url: 'https://shineonyou.no',
+    },
+    organizer: {
       '@type': 'MusicGroup',
       name: 'Shine On You',
       url: 'https://shineonyou.no',

--- a/src/pages/VideosPage.jsx
+++ b/src/pages/VideosPage.jsx
@@ -21,9 +21,15 @@ export default function VideosPage() {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
     name: v.title || `Shine On You – ${v.youtube_id}`,
+    description: v.title
+      ? `${v.title} — live performance by Shine On You, Pink Floyd tribute band.`
+      : "Live performance by Shine On You, Scandinavia's Pink Floyd tribute band.",
     embedUrl: `https://www.youtube.com/embed/${v.youtube_id}`,
     thumbnailUrl: `https://img.youtube.com/vi/${v.youtube_id}/hqdefault.jpg`,
     url: `https://www.youtube.com/watch?v=${v.youtube_id}`,
+    uploadDate: v.created_at
+      ? new Date(v.created_at).toISOString().split('T')[0]
+      : undefined,
   }))
 
   return (


### PR DESCRIPTION
## Problem

Google Rich Results Test revealed two issues after Phase 1 deploy:

- **`/videos` — 4 invalid items**: `uploadDate` is required by Google for VideoObject rich results. All videos were marked invalid.
- **`/tour` — 7 non-critical issues per MusicEvent**: Missing recommended fields (`description`, `url`, `organizer`).

## Changes

**VideoObject (`/videos`)**
- Add `uploadDate` using `created_at` from Supabase (already returned by `select('*')`, no DB migration needed)
- Add `description` field (optional but recommended)

**MusicEvent (`/tour` and `/`)**
- Add `description` — derived from venue/city
- Add `url` — ticket URL if available, otherwise `/tour`
- Add `organizer` — Shine On You MusicGroup

## Notes

- `/about` showing "No items detected" is **expected** — `Person` is not a Google rich result type. The schema still benefits AI crawlers.
- `/` "Something went wrong" was a transient Google tool error, not a code issue.

## Test plan

- [ ] Merge and deploy, then re-run Rich Results Test on `/videos` → should show valid VideoObjects
- [ ] Re-run Rich Results Test on `/tour` → non-critical issue count should decrease

🤖 Generated with [Claude Code](https://claude.com/claude-code)