### PR TITLE
fix: improve text contrast to meet WCAG 2 AA

### DIFF
--- a/src/components/Events.module.css
+++ b/src/components/Events.module.css
@@ -38,7 +38,7 @@
 .eventMonth {
   font-size: 14px;
   font-weight: 700;
-  color: #cc0000;
+  color: #ff2200;
   letter-spacing: 0.15em;
   text-transform: uppercase;
 }
@@ -88,7 +88,7 @@
 
 .tickets {
   flex-shrink: 0;
-  color: #cc0000;
+  color: #ff2200;
   font-size: 14px;
   font-weight: 700;
   letter-spacing: 0.12em;
@@ -96,9 +96,9 @@
 }
 
 .tickets a {
-  color: #cc0000;
+  color: #ff2200;
   text-decoration: none;
-  border: 2px solid #cc0000;
+  border: 2px solid #ff2200;
   border-radius: 3px;
   padding: 9px 22px;
   display: inline-block;
@@ -106,14 +106,14 @@
 }
 
 .tickets a:hover {
-  background: #cc0000;
+  background: #ff2200;
   color: #fff;
 }
 
 .tickets div {
   padding: 9px 22px;
   display: inline-block;
-  color: #555;
+  color: #888;
 }
 
 @media (max-width: 599px) {

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -6,7 +6,7 @@
 }
 
 .copy {
-  color: #555;
+  color: #999;
   font-size: 12px;
   margin: 0;
   letter-spacing: 0.04em;

--- a/src/pages/AboutPage.module.css
+++ b/src/pages/AboutPage.module.css
@@ -67,7 +67,7 @@
 
 .membersPhotoCredit {
   text-align: center;
-  color: #666;
+  color: #999;
   font-size: 12px;
   margin-top: 8px;
   margin-bottom: 32px;

--- a/src/pages/GalleryPage.module.css
+++ b/src/pages/GalleryPage.module.css
@@ -38,7 +38,7 @@
 
 .galleryPhotoCredit {
   text-align: center;
-  color: #666;
+  color: #999;
   font-size: 12px;
   margin-top: 16px;
   margin-bottom: 32px;


### PR DESCRIPTION
## Summary

- Footer copyright og photo credits (`#555`/`#666` → `#999`): 3.19–3.66:1 → **7.37:1**
- Tour månedsnavn og billett-knapper (`#cc0000` → `#ff2200`): 3.57:1 → **5.48:1**
- Tour "Coming Soon"/"Sold Out"-tekst (`#555` → `#888`): 3.19:1 → **5.91:1**

Alle berørte elementer overskrider nå WCAG 2 AA-grensen på 4.5:1 mot svart bakgrunn.

4 ARIA-feil på `/videos`-siden er ikke inkludert — disse er inne i YouTubes iframe-DOM og kan ikke fikses fra vår kode.

## Filer endret
- `src/components/Footer.module.css`
- `src/components/Events.module.css`
- `src/pages/AboutPage.module.css`
- `src/pages/GalleryPage.module.css`

## Test plan
- [ ] Besøk `/`, `/tour`, `/about`, `/gallery`, `/videos` og verifiser at tekst ser riktig ut visuelt
- [ ] Kjør axe eller tilsvarende a11y-verktøy og bekreft at kontrast-feilene er borte

🤖 Generated with [Claude Code](https://claude.com/claude-code)