### PR TITLE
fix: bump CI Node.js from 20 to 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## Summary
- Bumps `node-version` in the deploy workflow from `20` to `22`

## Root cause
PR #64 bumped `@supabase/supabase-js` to `2.106.2`, which pulled in a new version of `@supabase/realtime-js`. This version requires native WebSocket support, only available in Node.js 22+. On Node 20 it throws at build time when `generate-static.js` calls `createClient`.

The build passes locally because Node.js v22.12.0 is installed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)