### PR TITLE
fix: use rgba overlay to fix Chrome backdrop-filter on hero card

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -54,7 +54,7 @@ export default function Hero({ settings = {}, nextEvent, facebookUrl, instagramU
       style={bgImage ? { backgroundImage: `url(${bgImage})` } : undefined}
     >
       {bgImage && (
-        <div className={styles.overlay} style={{ opacity: overlayOpacity }} />
+        <div className={styles.overlay} style={{ background: `rgba(0, 0, 0, ${overlayOpacity})` }} />
       )}
       {bgImage && heroBackgroundCredit && (
         <p className={styles.heroCredit}>Photo: {heroBackgroundCredit}</p>

--- a/src/components/Hero.module.css
+++ b/src/components/Hero.module.css
@@ -29,7 +29,6 @@
 .overlay {
   position: absolute;
   inset: 0;
-  background: #000;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- The hero overlay used `opacity` as an inline style, which creates a CSS stacking context
- Chrome's `backdrop-filter` cannot pierce through a stacking context, so the frosted glass effect on the hero card was invisible in Chrome (card appeared transparent)
- Safari's `-webkit-backdrop-filter` handles this case differently, which is why it worked there

## Fix

Changed overlay from `background: #000; opacity: X` → `background: rgba(0, 0, 0, X)`. This removes the stacking context while producing identical visual output for the overlay darkening effect. Chrome's `backdrop-filter: blur(8px)` can now correctly capture the hero background image.

## Test plan

- [ ] Open in Chrome — hero card should show frosted glass blur effect
- [ ] Open in Safari — same frosted glass effect as before
- [ ] Check that hero overlay darkening still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)