### PR TITLE
fix: put -webkit-backdrop-filter before standard to survive Vite 8 minification

### DIFF
--- a/src/components/BetweenToursCard.module.css
+++ b/src/components/BetweenToursCard.module.css
@@ -2,8 +2,8 @@
   border: 1px solid #444;
   padding: 32px;
   background: rgba(0, 0, 0, var(--card-bg-alpha, 0.82));
-  backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
 }
 
 .eyebrow {

--- a/src/components/HeroCardSkeleton.module.css
+++ b/src/components/HeroCardSkeleton.module.css
@@ -2,8 +2,8 @@
   border: 1px solid #444;
   padding: 32px;
   background: rgba(0, 0, 0, var(--card-bg-alpha, 0.82));
-  backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
 }
 
 @keyframes shimmer {

--- a/src/components/NextShowCard.module.css
+++ b/src/components/NextShowCard.module.css
@@ -2,8 +2,8 @@
   border: 1px solid #444;
   padding: 32px;
   background: rgba(0, 0, 0, var(--card-bg-alpha, 0.82));
-  backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
 }
 
 .kicker {


### PR DESCRIPTION
## Summary

- Vite 8's CSS minifier removes `backdrop-filter` when both the standard and `-webkit-` versions are present and the **standard appears first**
- This left only `-webkit-backdrop-filter` in the production CSS bundle
- Modern Chrome desktop (76+) no longer recognises `-webkit-backdrop-filter` as an alias → no frosted glass effect on prod
- Safari and Chrome mobile were unaffected (Safari uses the webkit prefix natively)

## Fix

Swapped property order in all three hero card CSS modules so webkit prefix comes first, standard last — the conventional CSS practice:

```css
/* before */
backdrop-filter: blur(8px);
-webkit-backdrop-filter: blur(8px);

/* after */
-webkit-backdrop-filter: blur(8px);
backdrop-filter: blur(8px);
```

Verified: new prod build now contains `backdrop-filter:blur(8px)` (standard) in addition to the webkit version.

## Files changed
- `src/components/NextShowCard.module.css`
- `src/components/BetweenToursCard.module.css`
- `src/components/HeroCardSkeleton.module.css`

## Test plan
- [ ] Open prod in Chrome desktop — hero card should show frosted glass effect
- [ ] Open prod in Safari — frosted glass still works
- [ ] Open prod in Chrome mobile — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)