### PR TITLE
feat: mute colors on past shows

### DIFF
--- a/src/components/Events.jsx
+++ b/src/components/Events.jsx
@@ -19,7 +19,7 @@ function EventCard({ event, past }) {
   const year = d.getFullYear()
 
   return (
-    <div className={styles.event}>
+    <div className={`${styles.event}${past ? ` ${styles.pastEvent}` : ''}`}>
       <div className={styles.eventDateBlock}>
         <span className={styles.eventDay}>{day}</span>
         <span className={styles.eventMonth}>{month}</span>

--- a/src/components/Events.module.css
+++ b/src/components/Events.module.css
@@ -20,6 +20,23 @@
 }
 
 
+.pastEvent .eventDay,
+.pastEvent .eventYear {
+  color: #aaa;
+}
+
+.pastEvent .eventMonth {
+  color: #888;
+}
+
+.pastEvent .eventVenue {
+  color: #aaa;
+}
+
+.pastEvent .eventCity {
+  color: #777;
+}
+
 .eventDateBlock {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Past shows får nedtonede grå farger i stedet for samme hvit/rød som kommende konserter
- Dag, år og venue: `#aaa`, månedslabel: `#888` (fjerner rød), by: `#777`
- Ingen logikkendringer — bruker eksisterende `past`-prop på `EventCard` til å legge til `.pastEvent`-klasse

## Test plan

- [ ] Sjekk at past shows vises med nedtonede grå farger
- [ ] Sjekk at upcoming shows fortsatt er hvite med rød månedslabel og TICKETS-knapp
- [ ] Sjekk mobil (< 599px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)