### PR TITLE
Sikkerhet: escape DB-verdier i statisk HTML-fallback (F3)

### DIFF
--- a/scripts/generate-static.js
+++ b/scripts/generate-static.js
@@ -82,11 +82,18 @@ console.log('[generate-static] public/llms.txt written.')
 
 // ── index.html static fallback ───────────────────────────────────────────────
 
+// DB-verdier (venue/city/country) skrives som rå HTML inn i index.html, så de må
+// escapes for å unngå at admin-innhold (eller skrivetilgang via anon-nøkkel) blir HTML-injeksjon.
+const escapeHtml = (s) =>
+  String(s ?? '').replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  )
+
 const concertHtml = upcoming.length
   ? `<ul>${upcoming.slice(0, 5).map((e) => {
       const d = new Date(e.date)
       const label = d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
-      return `<li>${label} — ${e.venue}, ${e.city}, ${e.country}</li>`
+      return `<li>${label} — ${escapeHtml(e.venue)}, ${escapeHtml(e.city)}, ${escapeHtml(e.country)}</li>`
     }).join('')}</ul>`
   : '<p>No upcoming concerts scheduled.</p>'
 


### PR DESCRIPTION
## Hva
`scripts/generate-static.js` injiserte `venue`/`city`/`country` fra Supabase rett inn i `index.html` som rå HTML ved build. Denne PR-en legger til en `escapeHtml()`-helper og escaper DB-feltene i den statiske crawler-fallbacken.

## Hvorfor
Funn **F3** fra sikkerhetsgjennomgangen. Lav risiko (build-time + admin-innhold), men korrekt herding mot HTML-injeksjon — særlig siden event-data i prinsippet er redigerbart innhold.

## Test
- `node --check scripts/generate-static.js` ✓
- `vitest run` — 5/5 grønne ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)